### PR TITLE
[E2E] measure execution time to improve performance

### DIFF
--- a/deploy/e2e.mk
+++ b/deploy/e2e.mk
@@ -1,7 +1,7 @@
 E2E_PRIVATE_KEY_FOLDER_PATH ?= /etc/planner/e2e
 
 .PHONY: deploy-e2e-environment
-deploy-e2e-environment: install_qemu_img ignore_insecure_registry create_kind_e2e_cluster setup_libvirt generate_private_key deploy_registry deploy_vcsim build_assisted_migration_containers deploy_assisted_migration persistent_disk
+deploy-e2e-environment: install_qemu_img ignore_insecure_registry create_kind_e2e_cluster setup_libvirt generate_private_key deploy_registry deploy_vcsim build_assisted_migration_containers deploy_assisted_migration
 
 .PHONY: install_qemu_img
 install_qemu_img:
@@ -81,10 +81,6 @@ deploy_assisted_migration:
 	$(KUBECTL) port-forward --address 0.0.0.0 service/migration-planner-agent 7443:7443 > /dev/null 2>&1 &
 	$(KUBECTL) port-forward --address 0.0.0.0 service/migration-planner 3443:3443 > /dev/null 2>&1 &
 	$(KUBECTL) port-forward --address 0.0.0.0 service/migration-planner-image 11443:11443 > /dev/null 2>&1 &
-
-.PHONY: persistent_disk
-persistent_disk:
-	mkdir -p /tmp/untarova
 
 .PHONY: undeploy-e2e-environment
 undeploy-e2e-environment:

--- a/test/e2e/e2e_disconnected_env_test.go
+++ b/test/e2e/e2e_disconnected_env_test.go
@@ -69,7 +69,9 @@ var _ = Describe("e2e-disconnected-environment", func() {
 		Expect(err).To(BeNil(), "Failed to remove sources from DB")
 		err = agent.Remove()
 		Expect(err).To(BeNil(), "Failed to remove vm and iso")
-		zap.S().Infof("Test completed in: %s\n", time.Since(startTime))
+		testDuration := time.Since(startTime)
+		zap.S().Infof("Test completed in: %s\n", testDuration.String())
+		testsExecutionTime[CurrentSpecReport().LeafNodeText] = testDuration
 	})
 
 	AfterFailed(func() {
@@ -77,7 +79,7 @@ var _ = Describe("e2e-disconnected-environment", func() {
 	})
 
 	Context("Flow", func() {
-		It("disconnected-environment", func() {
+		It("Disconnected-environment", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
 			// Adding vcenter.com to /etc/hosts to enable connectivity to the vSphere server.

--- a/test/e2e/e2e_ova_from_url_test.go
+++ b/test/e2e/e2e_ova_from_url_test.go
@@ -65,7 +65,9 @@ var _ = Describe("e2e-download-ova-from-url", func() {
 		Expect(err).To(BeNil(), "Failed to remove sources from DB")
 		err = agent.Remove()
 		Expect(err).To(BeNil(), "Failed to remove vm and iso")
-		zap.S().Infof("Test completed in: %s\n", time.Since(startTime))
+		testDuration := time.Since(startTime)
+		zap.S().Infof("Test completed in: %s\n", testDuration.String())
+		testsExecutionTime[CurrentSpecReport().LeafNodeText] = testDuration
 	})
 
 	AfterFailed(func() {

--- a/test/e2e/e2e_utils_test.go
+++ b/test/e2e/e2e_utils_test.go
@@ -11,7 +11,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
+	"time"
 )
 
 // Create VM with the UUID of the source created
@@ -235,4 +237,28 @@ func RemoveFile(fullPath string) error {
 		}
 	}
 	return nil
+}
+
+func logExecutionSummary() {
+	zap.S().Infof("============Summarizing execution time============")
+
+	type testResult struct {
+		name     string
+		duration time.Duration
+	}
+
+	var results []testResult
+
+	for test, duration := range testsExecutionTime {
+		results = append(results, testResult{name: test, duration: duration})
+	}
+
+	// Sort tests by duration descending
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].duration > results[j].duration
+	})
+
+	for _, result := range results {
+		zap.S().Infof("[%s] finished after: %s", result.name, result.duration.Round(time.Second))
+	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Add performance measurement and logging for end-to-end (E2E) tests to track and summarize test execution times

Enhancements:
- Create a global map to store test execution times
- Sort and log test execution times from longest to shortest duration

Tests:
- Implement a mechanism to track and log execution time for individual E2E tests
- Add an AfterSuite hook to summarize test execution times in a sorted manner

Chores:
- Refactor test logging to capture more detailed execution time information
- Improve test naming for clarity