### PR TITLE
E2e use http directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ examples/config.yaml
 cover.out
 /docker-config/
 deploy/k8s/vcsim.yaml
+.idea/

--- a/deploy/e2e.mk
+++ b/deploy/e2e.mk
@@ -85,5 +85,4 @@ deploy_assisted_migration:
 .PHONY: undeploy-e2e-environment
 undeploy-e2e-environment:
 	kind delete cluster --name kind-e2e
-	rm ~/.config/planner/client.yaml
 	$(PODMAN) rmi $(MIGRATION_PLANNER_AGENT_IMAGE)

--- a/deploy/e2e.mk
+++ b/deploy/e2e.mk
@@ -1,7 +1,7 @@
 E2E_PRIVATE_KEY_FOLDER_PATH ?= /etc/planner/e2e
 
 .PHONY: deploy-e2e-environment
-deploy-e2e-environment: install_qemu_img ignore_insecure_registry create_kind_e2e_cluster setup_libvirt generate_private_key deploy_registry deploy_vcsim build_assisted_migration_containers deploy_assisted_migration persistent_disk
+deploy-e2e-environment: install_qemu_img ignore_insecure_registry create_kind_e2e_cluster setup_libvirt generate_private_key deploy_registry deploy_vcsim build_assisted_migration_containers deploy_assisted_migration
 
 .PHONY: install_qemu_img
 install_qemu_img:
@@ -81,10 +81,6 @@ deploy_assisted_migration:
 	$(KUBECTL) port-forward --address 0.0.0.0 service/migration-planner-agent 7443:7443 > /dev/null 2>&1 &
 	$(KUBECTL) port-forward --address 0.0.0.0 service/migration-planner 3443:3443 > /dev/null 2>&1 &
 	$(KUBECTL) port-forward --address 0.0.0.0 service/migration-planner-image 11443:11443 > /dev/null 2>&1 &
-
-.PHONY: persistent_disk
-persistent_disk:
-	mkdir -p /tmp/untarova
 
 .PHONY: undeploy-e2e-environment
 undeploy-e2e-environment:

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -179,6 +179,10 @@ objects:
                 tcpSocket:
                   port: 3443
                 initialDelaySeconds: 30
+              readinessProbe:
+                tcpSocket:
+                  port: 7443
+                initialDelaySeconds: 30
               env:
                 - name: CONFIG_SERVER
                   value: ${MIGRATION_PLANNER_URL}

--- a/internal/store/cache_key.go
+++ b/internal/store/cache_key.go
@@ -41,16 +41,14 @@ func (p *CachePrivateKeyStore) Delete(ctx context.Context, orgID string) error {
 }
 
 func (p *CachePrivateKeyStore) GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error) {
-	if len(p.publicKeys) != 0 {
-		return p.publicKeys, nil
-	}
+	// if len(p.publicKeys) != 0 {
+	// 	return p.publicKeys, nil
+	// }
 
 	pb, err := p.delegate.GetPublicKeys(ctx)
 	if err != nil {
 		return make(map[string]crypto.PublicKey), err
 	}
-
-	p.publicKeys = pb
 
 	return pb, nil
 }

--- a/internal/store/cache_key.go
+++ b/internal/store/cache_key.go
@@ -3,52 +3,63 @@ package store
 import (
 	"context"
 	"crypto"
+	"sync"
 
 	"github.com/kubev2v/migration-planner/internal/store/model"
 )
 
-// CachePrivateKeyStore is wrapper around PrivateKeyStore which provide basic caching of the public keys.
-type CachePrivateKeyStore struct {
+// CacheKeyStore is wrapper around PrivateKeyStore which provide basic caching of the public keys.
+type CacheKeyStore struct {
 	delegate   PrivateKey
 	publicKeys map[string]crypto.PublicKey
+	mu         sync.Mutex
 }
 
-func NewCachePrivateKeyStore(delegate PrivateKey) PrivateKey {
-	return &CachePrivateKeyStore{
+func NewCacheKeyStore(delegate PrivateKey) PrivateKey {
+	return &CacheKeyStore{
 		delegate:   delegate,
 		publicKeys: make(map[string]crypto.PublicKey),
 	}
 }
 
-func (p *CachePrivateKeyStore) Create(ctx context.Context, privateKey model.Key) (*model.Key, error) {
+func (p *CacheKeyStore) Create(ctx context.Context, privateKey model.Key) (*model.Key, error) {
 	r, err := p.delegate.Create(ctx, privateKey)
 	if err != nil {
 		return r, err
 	}
 
 	// invalidate cache
+	p.mu.Lock()
 	p.publicKeys = make(map[string]crypto.PublicKey)
+	p.mu.Unlock()
 
 	return r, nil
 }
 
-func (p *CachePrivateKeyStore) Get(ctx context.Context, orgID string) (*model.Key, error) {
+func (p *CacheKeyStore) Get(ctx context.Context, orgID string) (*model.Key, error) {
 	return p.delegate.Get(ctx, orgID)
 }
 
-func (p *CachePrivateKeyStore) Delete(ctx context.Context, orgID string) error {
+func (p *CacheKeyStore) Delete(ctx context.Context, orgID string) error {
 	return p.delegate.Delete(ctx, orgID)
 }
 
-func (p *CachePrivateKeyStore) GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error) {
-	// if len(p.publicKeys) != 0 {
-	// 	return p.publicKeys, nil
-	// }
+func (p *CacheKeyStore) GetPublicKeys(ctx context.Context) (map[string]crypto.PublicKey, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.publicKeys) != 0 {
+		return p.publicKeys, nil
+	}
 
 	pb, err := p.delegate.GetPublicKeys(ctx)
 	if err != nil {
 		return make(map[string]crypto.PublicKey), err
 	}
 
-	return pb, nil
+	for k, v := range pb {
+		p.publicKeys[k] = v
+	}
+
+	return p.publicKeys, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,7 +33,7 @@ func NewStore(db *gorm.DB) Store {
 		agent:      NewAgentSource(db),
 		source:     NewSource(db),
 		imageInfra: NewImageInfraStore(db),
-		privateKey: NewCachePrivateKeyStore(NewPrivateKey(db)),
+		privateKey: NewCacheKeyStore(NewPrivateKey(db)),
 		db:         db,
 	}
 }

--- a/pkg/migrations/sql/20250414125006_remove_org_username_agent.sql
+++ b/pkg/migrations/sql/20250414125006_remove_org_username_agent.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE agents DROP COLUMN IF EXISTS username;
+ALTER TABLE agents DROP COLUMN IF EXISTS org_id;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- no statement because this migration is done to sync the old schema with the current one.
+-- +goose StatementEnd

--- a/test/e2e/e2e_agent_test.go
+++ b/test/e2e/e2e_agent_test.go
@@ -2,12 +2,9 @@ package e2e_test
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/kubev2v/migration-planner/internal/agent/common"
 	"go.uber.org/zap"
 	"io"
 	"net/http"
@@ -17,10 +14,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
-	api "github.com/kubev2v/migration-planner/api/v1alpha1"
-	internalclient "github.com/kubev2v/migration-planner/internal/api/client"
-	"github.com/kubev2v/migration-planner/internal/auth"
-	"github.com/kubev2v/migration-planner/internal/client"
 	libvirt "github.com/libvirt/libvirt-go"
 	. "github.com/onsi/ginkgo/v2"
 
@@ -40,17 +33,15 @@ const (
 
 var (
 	home               string = os.Getenv("HOME")
-	defaultConfigPath  string = filepath.Join(home, ".config/planner/client.yaml")
 	defaultBasePath    string = "/tmp/untarova/"
 	defaultVmdkName    string = filepath.Join(defaultBasePath, "persistence-disk.vmdk")
 	defaultOvaPath     string = filepath.Join(home, "myimage.ova")
-	defaultServiceUrl  string = fmt.Sprintf("http://%s:3443", os.Getenv("PLANNER_IP"))
 	defaultAgentTestID string = "1"
 	privateKeyPath     string = filepath.Join(os.Getenv("E2E_PRIVATE_KEY_FOLDER_PATH"), "private-key")
 )
 
 type PlannerAgent interface {
-	AgentApi() (*AgentApi, error)
+	AgentApi() *AgentApi
 	Run() error
 	Restart() error
 	Remove() error
@@ -66,25 +57,13 @@ type PlannerAgentAPI interface {
 	Inventory() (*v1alpha1.Inventory, error)
 }
 
-type PlannerService interface {
-	RemoveSources() error
-	RemoveSource(id uuid.UUID) error
-	GetSource(id uuid.UUID) (*api.Source, error)
-	CreateSource(name string) (*api.Source, error)
-	UpdateSource(uuid.UUID, *v1alpha1.Inventory) error
-}
-
-type plannerService struct {
-	c *internalclient.ClientWithResponses
-}
-
 type plannerAgentLibvirt struct {
-	c                   *internalclient.ClientWithResponses
+	ServiceApi          *ServiceApi
+	LocalApi            *AgentApi
 	name                string
 	con                 *libvirt.Connect
 	sourceID            uuid.UUID
 	agentEndToEndTestID string
-	localApi            *AgentApi
 }
 
 type AgentApi struct {
@@ -92,32 +71,15 @@ type AgentApi struct {
 	httpClient *http.Client
 }
 
-func NewPlannerAgent(configPath string, sourceID uuid.UUID, name string, idForTest string) (*plannerAgentLibvirt, error) {
-	_ = createConfigFile(configPath)
-
-	c, err := client.NewFromConfigFile(configPath)
-	if err != nil {
-		return nil, fmt.Errorf("creating client: %w", err)
-	}
+func NewPlannerAgent(sourceID uuid.UUID, name string, idForTest string) (*plannerAgentLibvirt, error) {
 
 	conn, err := libvirt.NewConnect("qemu:///system")
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to hypervisor: %v", err)
 	}
 
-	return &plannerAgentLibvirt{c: c, name: name, con: conn, sourceID: sourceID, agentEndToEndTestID: idForTest}, nil
-}
-
-func (p *plannerAgentLibvirt) AgentApi() (*AgentApi, error) {
-	if p.localApi != nil {
-		return p.localApi, nil
-	}
-	agentIP, err := p.GetIp()
-	if err != nil {
-		return nil, err
-	}
-	p.localApi = NewAgentApi(fmt.Sprintf("https://%s:3333/api/v1/", agentIP))
-	return p.localApi, nil
+	return &plannerAgentLibvirt{ServiceApi: NewServiceApi(), LocalApi: NewAgentApi(), name: name,
+		con: conn, sourceID: sourceID, agentEndToEndTestID: idForTest}, nil
 }
 
 func (p *plannerAgentLibvirt) Run() error {
@@ -131,6 +93,10 @@ func (p *plannerAgentLibvirt) Run() error {
 	}
 
 	return nil
+}
+
+func (p *plannerAgentLibvirt) AgentApi() *AgentApi {
+	return p.LocalApi
 }
 
 func (p *plannerAgentLibvirt) prepareImage() error {
@@ -151,11 +117,11 @@ func (p *plannerAgentLibvirt) prepareImage() error {
 	if err != nil {
 		return err
 	}
-	ctx := contextWithJWT(auth.NewTokenContext(context.TODO(), user), user.Token.Raw)
+
 	var res *http.Response
 
 	if testOptions.downloadImageByUrl {
-		url, err := p.getDownloadURL(ctx)
+		url, err := p.getDownloadURL(user.Token.Raw)
 		if err != nil {
 			return err
 		}
@@ -165,13 +131,19 @@ func (p *plannerAgentLibvirt) prepareImage() error {
 			return err
 		}
 	} else {
-		res, err = p.c.GetImage(ctx, p.sourceID, attachJWT) // Stream the OVA directly to res
+		getImagePath := "/" + p.sourceID.String() + "/" + "image"
+		res, err = p.ServiceApi.request(http.MethodGet, getImagePath, nil, user.Token.Raw)
+
 		if err != nil {
 			return fmt.Errorf("failed to get source image: %w", err)
 		}
 	}
 
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download image: %s", res.Status)
+	}
 
 	if _, err = io.Copy(ovaFile, res.Body); err != nil {
 		return fmt.Errorf("failed to write to the file: %w", err)
@@ -194,8 +166,9 @@ func (p *plannerAgentLibvirt) prepareImage() error {
 	return nil
 }
 
-func (p *plannerAgentLibvirt) getDownloadURL(ctx context.Context) (string, error) {
-	res, err := p.c.GetSourceDownloadURL(ctx, p.sourceID, attachJWT)
+func (p *plannerAgentLibvirt) getDownloadURL(jwtToken string) (string, error) {
+	getImageUrlPath := "/" + p.sourceID.String() + "/" + "image-url"
+	res, err := p.ServiceApi.request(http.MethodGet, getImageUrlPath, nil, jwtToken)
 	if err != nil {
 		return "", fmt.Errorf("failed to get source url: %w", err)
 	}
@@ -369,9 +342,31 @@ func (p *plannerAgentLibvirt) RestartService() error {
 	return nil
 }
 
-func NewAgentApi(baseURL string) *AgentApi {
+func (p *plannerAgentLibvirt) getConfigXmlVMPath() string {
+	if p.agentEndToEndTestID == defaultAgentTestID {
+		return "data/vm.xml"
+	}
+	return fmt.Sprintf("data/vm-%s.xml", p.agentEndToEndTestID)
+}
+
+func (p *plannerAgentLibvirt) IsoFilePath() string {
+	if p.agentEndToEndTestID == defaultAgentTestID {
+		return filepath.Join(defaultBasePath, "agent.iso")
+	}
+	fileName := fmt.Sprintf("agent-%s.iso", p.agentEndToEndTestID)
+	return filepath.Join(defaultBasePath, fileName)
+}
+
+func (p *plannerAgentLibvirt) qcowDiskFilePath() string {
+	if p.agentEndToEndTestID == defaultAgentTestID {
+		return filepath.Join(defaultBasePath, "persistence-disk.qcow2")
+	}
+	fileName := fmt.Sprintf("persistence-disk-vm-%s.qcow2", p.agentEndToEndTestID)
+	return filepath.Join(defaultBasePath, fileName)
+}
+
+func NewAgentApi() *AgentApi {
 	return &AgentApi{
-		baseURL: baseURL,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
@@ -464,176 +459,4 @@ func (api *AgentApi) Inventory() (*v1alpha1.Inventory, error) {
 	}
 
 	return &result.Inventory, nil
-}
-
-func NewPlannerService(configPath string) (*plannerService, error) {
-	zap.S().Info("Initializing PlannerService...")
-	_ = createConfigFile(configPath)
-	c, err := client.NewFromConfigFile(configPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %w", err)
-	}
-
-	zap.S().Info("PlannerService created successfully")
-	return &plannerService{c: c}, nil
-}
-
-func (s *plannerService) CreateSource(name string) (*api.Source, error) {
-	zap.S().Info("Creating source...")
-	user, err := defaultUserAuth()
-	if err != nil {
-		return nil, err
-	}
-	ctx := contextWithJWT(auth.NewTokenContext(context.TODO(), user), user.Token.Raw)
-
-	params := v1alpha1.CreateSourceJSONRequestBody{Name: name}
-
-	if testOptions.disconnectedEnvironment { // make the service unreachable
-
-		toStrPtr := func(s string) *string {
-			return &s
-		}
-
-		params.Proxy = &api.AgentProxy{
-			HttpUrl:  toStrPtr("127.0.0.1"),
-			HttpsUrl: toStrPtr("127.0.0.1"),
-			NoProxy:  toStrPtr("vcenter.com"),
-		}
-	}
-
-	res, err := s.c.CreateSourceWithResponse(ctx, params, attachJWT)
-	if err != nil || res.HTTPResponse.StatusCode != 201 {
-		return nil, fmt.Errorf("failed to create the source: %v", err)
-	}
-
-	if res.JSON201 == nil {
-		return nil, fmt.Errorf("failed to create the source")
-	}
-
-	zap.S().Info("Source created successfully")
-	return res.JSON201, nil
-}
-
-func (s *plannerService) GetSource(id uuid.UUID) (*api.Source, error) {
-	user, err := defaultUserAuth()
-	if err != nil {
-		return nil, err
-	}
-	ctx := contextWithJWT(auth.NewTokenContext(context.TODO(), user), user.Token.Raw)
-
-	res, err := s.c.GetSourceWithResponse(ctx, id, attachJWT)
-	if err != nil || res.HTTPResponse.StatusCode != 200 {
-		return nil, fmt.Errorf("failed to list sources. response status code: %d", res.HTTPResponse.StatusCode)
-	}
-
-	return res.JSON200, nil
-}
-
-func (s *plannerService) RemoveSources() error {
-	user, err := defaultUserAuth()
-	if err != nil {
-		return err
-	}
-	ctx := contextWithJWT(auth.NewTokenContext(context.TODO(), user), user.Token.Raw)
-
-	_, err = s.c.DeleteSourcesWithResponse(ctx, attachJWT)
-	return err
-}
-
-func (s *plannerService) RemoveSource(uuid uuid.UUID) error {
-	user, err := defaultUserAuth()
-	if err != nil {
-		return err
-	}
-	ctx := contextWithJWT(auth.NewTokenContext(context.TODO(), user), user.Token.Raw)
-
-	_, err = s.c.DeleteSourceWithResponse(ctx, uuid, attachJWT)
-	return err
-}
-
-func (s *plannerService) UpdateSource(uuid uuid.UUID, inventory *v1alpha1.Inventory) error {
-	update := v1alpha1.UpdateSourceJSONRequestBody{
-		AgentId:   uuid,
-		Inventory: *inventory,
-	}
-
-	user, err := defaultUserAuth()
-	if err != nil {
-		return err
-	}
-	ctx := contextWithJWT(auth.NewTokenContext(context.TODO(), user), user.Token.Raw)
-
-	_, err = s.c.UpdateSourceWithResponse(ctx, uuid, update, attachJWT)
-	return err
-}
-
-func createConfigFile(configPath string) error {
-	// Ensure the directory exists
-	dir := filepath.Dir(configPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory structure: %w", err)
-	}
-
-	// Create configuration
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return os.WriteFile(configPath, []byte(fmt.Sprintf("service:\n  server: %s", defaultServiceUrl)), 0644)
-	}
-
-	return nil
-}
-
-func (p *plannerAgentLibvirt) getConfigXmlVMPath() string {
-	if p.agentEndToEndTestID == defaultAgentTestID {
-		return "data/vm.xml"
-	}
-	return fmt.Sprintf("data/vm-%s.xml", p.agentEndToEndTestID)
-}
-
-func (p *plannerAgentLibvirt) IsoFilePath() string {
-	if p.agentEndToEndTestID == defaultAgentTestID {
-		return filepath.Join(defaultBasePath, "agent.iso")
-	}
-	fileName := fmt.Sprintf("agent-%s.iso", p.agentEndToEndTestID)
-	return filepath.Join(defaultBasePath, fileName)
-}
-
-func (p *plannerAgentLibvirt) qcowDiskFilePath() string {
-	if p.agentEndToEndTestID == defaultAgentTestID {
-		return filepath.Join(defaultBasePath, "persistence-disk.qcow2")
-	}
-	fileName := fmt.Sprintf("persistence-disk-vm-%s.qcow2", p.agentEndToEndTestID)
-	return filepath.Join(defaultBasePath, fileName)
-}
-
-func defaultUserAuth() (*auth.User, error) {
-	tokenVal, err := getToken(defaultUsername, defaultOrganization)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create user: %v", err)
-	}
-	token := jwt.New(jwt.SigningMethodRS256)
-	token.Raw = tokenVal
-	return &auth.User{
-		Username:     defaultUsername,
-		Organization: defaultOrganization,
-		Token:        token,
-	}, nil
-}
-
-func attachJWT(ctx context.Context, req *http.Request) error {
-	if jwt, found := jwtFromContext(ctx); found {
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
-	}
-	return nil
-}
-
-func jwtFromContext(ctx context.Context) (string, bool) {
-	val := ctx.Value(common.JwtKey)
-	if val == nil {
-		return "", false
-	}
-	return val.(string), true
-}
-
-func contextWithJWT(ctx context.Context, jwt string) context.Context {
-	return context.WithValue(ctx, common.JwtKey, jwt)
 }

--- a/test/e2e/e2e_disconnected_env_test.go
+++ b/test/e2e/e2e_disconnected_env_test.go
@@ -69,7 +69,9 @@ var _ = Describe("e2e-disconnected-environment", func() {
 		Expect(err).To(BeNil(), "Failed to remove sources from DB")
 		err = agent.Remove()
 		Expect(err).To(BeNil(), "Failed to remove vm and iso")
-		zap.S().Infof("Test completed in: %s\n", time.Since(startTime))
+		testDuration := time.Since(startTime)
+		zap.S().Infof("Test completed in: %s\n", testDuration.String())
+		testsExecutionTime[CurrentSpecReport().LeafNodeText] = testDuration
 	})
 
 	AfterFailed(func() {
@@ -77,7 +79,7 @@ var _ = Describe("e2e-disconnected-environment", func() {
 	})
 
 	Context("Flow", func() {
-		It("disconnected-environment", func() {
+		It("Disconnected-environment", func() {
 			zap.S().Infof("============Running test: %s============", CurrentSpecReport().LeafNodeText)
 
 			// Adding vcenter.com to /etc/hosts to enable connectivity to the vSphere server.

--- a/test/e2e/e2e_ova_from_url_test.go
+++ b/test/e2e/e2e_ova_from_url_test.go
@@ -65,7 +65,9 @@ var _ = Describe("e2e-download-ova-from-url", func() {
 		Expect(err).To(BeNil(), "Failed to remove sources from DB")
 		err = agent.Remove()
 		Expect(err).To(BeNil(), "Failed to remove vm and iso")
-		zap.S().Infof("Test completed in: %s\n", time.Since(startTime))
+		testDuration := time.Since(startTime)
+		zap.S().Infof("Test completed in: %s\n", testDuration.String())
+		testsExecutionTime[CurrentSpecReport().LeafNodeText] = testDuration
 	})
 
 	AfterFailed(func() {

--- a/test/e2e/e2e_service_test.go
+++ b/test/e2e/e2e_service_test.go
@@ -1,0 +1,216 @@
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/kubev2v/migration-planner/api/v1alpha1"
+	api "github.com/kubev2v/migration-planner/api/v1alpha1"
+	internalclient "github.com/kubev2v/migration-planner/internal/api/client"
+	"go.uber.org/zap"
+	"net/http"
+	"os"
+)
+
+type PlannerService interface {
+	RemoveSources() error
+	RemoveSource(id uuid.UUID) error
+	GetSource(id uuid.UUID) (*api.Source, error)
+	CreateSource(name string) (*api.Source, error)
+	UpdateSource(uuid.UUID, *v1alpha1.Inventory) error
+}
+
+var (
+	defaultServiceUrl string = fmt.Sprintf("http://%s:3443", os.Getenv("PLANNER_IP"))
+)
+
+type plannerService struct {
+	//c   *internalclient.ClientWithResponses
+	api *ServiceApi
+}
+
+type ServiceApi struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewPlannerService() (*plannerService, error) {
+	zap.S().Info("Initializing PlannerService...")
+	return &plannerService{api: NewServiceApi()}, nil
+}
+
+func (s *plannerService) CreateSource(name string) (*api.Source, error) {
+	zap.S().Info("Creating source...")
+	user, err := defaultUserAuth()
+	if err != nil {
+		return nil, err
+	}
+
+	params := &v1alpha1.CreateSourceJSONRequestBody{Name: name}
+
+	if testOptions.disconnectedEnvironment { // make the service unreachable
+
+		toStrPtr := func(s string) *string {
+			return &s
+		}
+
+		params.Proxy = &api.AgentProxy{
+			HttpUrl:  toStrPtr("127.0.0.1"),
+			HttpsUrl: toStrPtr("127.0.0.1"),
+			NoProxy:  toStrPtr("vcenter.com"),
+		}
+	}
+
+	reqBody, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := s.api.request(http.MethodPost, "", reqBody, user.Token.Raw)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	createSourceRes, err := internalclient.ParseCreateSourceResponse(res)
+	if err != nil || createSourceRes.HTTPResponse.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create the source: %v", err)
+	}
+
+	if createSourceRes.JSON201 == nil {
+		return nil, fmt.Errorf("failed to create the source")
+	}
+
+	zap.S().Info("Source created successfully")
+
+	return createSourceRes.JSON201, nil
+}
+
+func (s *plannerService) GetSource(id uuid.UUID) (*api.Source, error) {
+	user, err := defaultUserAuth()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := s.api.request(http.MethodGet, "/"+id.String(), nil, user.Token.Raw)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	getSourceRes, err := internalclient.ParseGetSourceResponse(res)
+	if err != nil || getSourceRes.HTTPResponse.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to list sources. response status code: %d", getSourceRes.HTTPResponse.StatusCode)
+	}
+
+	return getSourceRes.JSON200, nil
+}
+
+func (s *plannerService) RemoveSources() error {
+	user, err := defaultUserAuth()
+	if err != nil {
+		return err
+	}
+
+	res, err := s.api.request(http.MethodDelete, "", nil, user.Token.Raw)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete sources. response status code: %d", res.StatusCode)
+	}
+
+	return err
+}
+
+func (s *plannerService) RemoveSource(uuid uuid.UUID) error {
+	user, err := defaultUserAuth()
+	if err != nil {
+		return err
+	}
+
+	res, err := s.api.request(http.MethodDelete, "/"+uuid.String(), nil, user.Token.Raw)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to delete source with uuid: %s. "+
+			"response status code: %d", uuid.String(), res.StatusCode)
+	}
+
+	return err
+}
+
+func (s *plannerService) UpdateSource(uuid uuid.UUID, inventory *v1alpha1.Inventory) error {
+	user, err := defaultUserAuth()
+	if err != nil {
+		return err
+	}
+
+	update := v1alpha1.UpdateSourceJSONRequestBody{
+		AgentId:   uuid,
+		Inventory: *inventory,
+	}
+
+	reqBody, err := json.Marshal(update)
+	if err != nil {
+		return err
+	}
+
+	res, err := s.api.request(http.MethodPut, "/"+uuid.String(), reqBody, user.Token.Raw)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to update source with uuid: %s. "+
+			"response status code: %d", uuid.String(), res.StatusCode)
+	}
+
+	return err
+}
+
+func NewServiceApi() *ServiceApi {
+	return &ServiceApi{
+		baseURL:    fmt.Sprintf("%s/api/v1/sources", defaultServiceUrl),
+		httpClient: &http.Client{},
+	}
+}
+
+func (api *ServiceApi) request(method string, path string, body []byte, jwtToken string) (*http.Response, error) {
+	var req *http.Request
+	var err error
+
+	switch method {
+	case http.MethodGet:
+		req, err = http.NewRequest(http.MethodGet, api.baseURL+path, nil)
+	case http.MethodPost:
+		req, err = http.NewRequest(http.MethodPost, api.baseURL+path, bytes.NewReader(body))
+	case http.MethodPut:
+		req, err = http.NewRequest(http.MethodPut, api.baseURL+path, bytes.NewReader(body))
+	case http.MethodDelete:
+		req, err = http.NewRequest(http.MethodDelete, api.baseURL+path, nil)
+	default:
+		return nil, fmt.Errorf("unsupported method: %s", method)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwtToken))
+
+	res, err := api.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/test/e2e/e2e_utils_test.go
+++ b/test/e2e/e2e_utils_test.go
@@ -11,7 +11,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
+	"time"
 )
 
 // Create VM with the UUID of the source created
@@ -235,4 +237,28 @@ func RemoveFile(fullPath string) error {
 		}
 	}
 	return nil
+}
+
+func logExecutionSummary() {
+	zap.S().Infof("============Summarizing execution time============")
+
+	type testResult struct {
+		name     string
+		duration time.Duration
+	}
+
+	var results []testResult
+
+	for test, duration := range testsExecutionTime {
+		results = append(results, testResult{name: test, duration: duration})
+	}
+
+	// Sort tests by duration descending
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].duration > results[j].duration
+	})
+
+	for _, result := range results {
+		zap.S().Infof("[%s] finished after: %s", result.name, result.duration.Round(time.Second))
+	}
 }

--- a/test/e2e/e2e_utils_test.go
+++ b/test/e2e/e2e_utils_test.go
@@ -4,8 +4,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/kubev2v/migration-planner/api/v1alpha1"
+	"github.com/kubev2v/migration-planner/internal/auth"
 	"github.com/kubev2v/migration-planner/internal/cli"
 	"go.uber.org/zap"
 	"io"
@@ -17,9 +19,9 @@ import (
 )
 
 // Create VM with the UUID of the source created
-func CreateAgent(configPath string, idForTest string, uuid uuid.UUID, vmName string) (PlannerAgent, error) {
+func CreateAgent(idForTest string, uuid uuid.UUID, vmName string) (PlannerAgent, error) {
 	zap.S().Info("Creating agent...")
-	agent, err := NewPlannerAgent(configPath, uuid, vmName, idForTest)
+	agent, err := NewPlannerAgent(uuid, vmName, idForTest)
 	if err != nil {
 		return nil, err
 	}
@@ -237,6 +239,20 @@ func RemoveFile(fullPath string) error {
 		}
 	}
 	return nil
+}
+
+func defaultUserAuth() (*auth.User, error) {
+	tokenVal, err := getToken(defaultUsername, defaultOrganization)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create user: %v", err)
+	}
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Raw = tokenVal
+	return &auth.User{
+		Username:     defaultUsername,
+		Organization: defaultOrganization,
+		Token:        token,
+	}, nil
 }
 
 func logExecutionSummary() {


### PR DESCRIPTION
## Summary by Sourcery

Refactor end-to-end tests to use direct HTTP requests instead of generated client, simplifying the test infrastructure and removing unnecessary dependencies.

Enhancements:
- Simplified HTTP request handling in test infrastructure
- Removed unnecessary client generation and configuration code
- Added test execution time tracking

Build:
- Added a new SQL migration to remove unused columns from agents table

Tests:
- Modified test setup to use direct HTTP calls
- Added execution time logging for tests
- Updated test methods to remove configuration file dependencies

Chores:
- Removed unused imports and configuration-related code
- Simplified service and agent initialization in tests