### PR TITLE
iso: Implement a rolling iso image initializer

### DIFF
--- a/cmd/planner-api/init.go
+++ b/cmd/planner-api/init.go
@@ -2,57 +2,112 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/kubev2v/migration-planner/internal/config"
-	"github.com/kubev2v/migration-planner/internal/util"
-	"github.com/kubev2v/migration-planner/pkg/iso"
+	"github.com/kubev2v/migration-planner/internal/api_server/isoserver"
 	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/kubev2v/migration-planner/pkg/iso"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize RHCOS ISO for the migration planner",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		defer zap.S().Info("ISO initialization completed")
+type InitOptions struct {
+	Serve bool
+	Port  string
+}
 
-		cfg, err := config.New()
-		if err != nil {
-			zap.S().Fatalw("reading configuration", "error", err)
+func DefaultInitOptions() *InitOptions {
+	return &InitOptions{
+		Serve: false,
+	}
+}
+
+func NewCmdInit() *cobra.Command {
+	o := DefaultInitOptions()
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize RHCOS ISO for the migration planner",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.New()
+			if err != nil {
+				return fmt.Errorf("reading config: %w", err)
+			}
+			_, undo := setupLogger(cfg.Service.LogLevel)
+			defer undo()
+			zap.S().Info("Starting ISO initialization...")
+
+			ctx, cancel := setupSignalContext()
+			defer cancel()
+
+			if err := runISOInit(ctx, cfg); err != nil {
+				return err
+			}
+
+			if o.Serve {
+				return serveISO(ctx, o.Port, cfg.Service.IsoPath)
+			}
+			return nil
+		},
+	}
+
+	cmd.SilenceUsage = true
+	o.Bind(cmd.Flags())
+	return cmd
+}
+
+func setupLogger(levelStr string) (*zap.Logger, func()) {
+	level, err := zap.ParseAtomicLevel(levelStr)
+	if err != nil {
+		level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	}
+	logger := log.InitLog(level)
+	undo := zap.ReplaceGlobals(logger)
+	return logger, func() { _ = logger.Sync(); undo() }
+}
+
+func setupSignalContext() (context.Context, func()) {
+	ctx, cancel := signal.NotifyContext(
+		context.Background(),
+		os.Interrupt, syscall.SIGHUP,
+		syscall.SIGTERM, syscall.SIGQUIT,
+	)
+	return ctx, cancel
+}
+
+func runISOInit(ctx context.Context, cfg *config.Config) error {
+	zap.S().Info("Initializing RHCOS ISO")
+	isoInit := newIsoInitializer(cfg)
+	if err := isoInit.Initialize(ctx, cfg.Service.IsoPath, cfg.Service.RhcosImageSha256); err != nil {
+		if _, err := os.Stat(cfg.Service.IsoPath); err != nil {
+			return fmt.Errorf("initialize iso: %w", err)
 		}
-
-		logLvl, err := zap.ParseAtomicLevel(cfg.Service.LogLevel)
-		if err != nil {
-			logLvl = zap.NewAtomicLevelAt(zapcore.InfoLevel)
-		}
-
-		logger := log.InitLog(logLvl)
-		defer func() { _ = logger.Sync() }()
-
-		undo := zap.ReplaceGlobals(logger)
-		defer undo()
-
-		zap.S().Info("Starting ISO initialization...")
-
-		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
-		defer cancel()
-
-		// Initialize ISOs
-		zap.S().Info("Initializing RHCOS ISO")
-		isoInitializer := newIsoInitializer(cfg)
-		targetIsoFile := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
-		if err := isoInitializer.Initialize(ctx, targetIsoFile, cfg.Service.RhcosImageSha256); err != nil {
-			zap.S().Fatalw("failed to initialize iso", "error", err)
-		}
+		zap.S().Warnf("error initializing iso: %v. proceed with old Iso...", err)
+	} else {
 		zap.S().Info("RHCOS ISO initialized successfully")
+	}
+	return nil
+}
 
-		return nil
-	},
+func serveISO(ctx context.Context, port, isoPath string) error {
+	addr := fmt.Sprintf("0.0.0.0:%s", port)
+	ln, err := newListener(addr)
+	if err != nil {
+		return fmt.Errorf("creating listener: %w", err)
+	}
+	server := isoserver.New(ln, addr, isoPath)
+	return server.Run(ctx)
+}
+
+func (o *InitOptions) Bind(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.Serve, "listen", false, "listen to serve the iso file")
+	fs.StringVarP(&o.Port, "port", "p", "8080", "Port to listen on")
 }
 
 func newIsoInitializer(cfg *config.Config) *iso.IsoInitializer {

--- a/cmd/planner-api/root.go
+++ b/cmd/planner-api/root.go
@@ -11,7 +11,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(NewCmdInit())
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(runCmd)
 

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -13,7 +14,6 @@ import (
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/opa"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/internal/util"
 	"github.com/kubev2v/migration-planner/pkg/iso"
 	"github.com/kubev2v/migration-planner/pkg/log"
 	"github.com/kubev2v/migration-planner/pkg/metrics"
@@ -153,7 +153,7 @@ func newListener(address string) (net.Listener, error) {
 
 func initializeIso(ctx context.Context, cfg *config.Config) error {
 	// Check if ISO already exists:
-	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
+	isoPath := cfg.Service.IsoPath
 	if _, err := os.Stat(isoPath); err == nil {
 		return nil
 	}
@@ -166,20 +166,20 @@ func initializeIso(ctx context.Context, cfg *config.Config) error {
 
 	md := iso.NewDownloaderManager()
 
-	minio, err := iso.NewMinioDownloader(
-		iso.WithEndpoint(cfg.Service.S3.Endpoint),
-		iso.WithBucket(cfg.Service.S3.Bucket),
-		iso.WithAccessKey(cfg.Service.S3.AccessKey),
-		iso.WithSecretKey(cfg.Service.S3.SecretKey),
-		iso.WithImage(cfg.Service.S3.IsoFileName, cfg.Service.RhcosImageSha256),
+	isoServerUrl := fmt.Sprintf("%s:%s", cfg.Service.IsoServerBaseURL, cfg.Service.IsoServerPort)
+	isoServerDownloader := iso.NewIsoServerDownloader(
+		isoServerUrl,
+		cfg.Service.RhcosImageSha256,
 	)
-	if err == nil {
-		md.Register(minio)
+
+	if err := isoServerDownloader.HealthCheck(ctx); err == nil {
+		md.Register(isoServerDownloader)
+		zap.S().Infow("Registered ISO server downloader", "url", isoServerUrl)
 	} else {
-		zap.S().Errorw("failed to create minio downloader", "error", err)
+		zap.S().Warnw("ISO server health check failed", "error", err, "url", isoServerUrl)
 	}
 
-	// register the default downloader of the official RHCOS image.
+	// Fallback: Official RHCOS HTTP downloader
 	md.Register(iso.NewHttpDownloader(cfg.Service.RhcosImageName, cfg.Service.RhcosImageSha256))
 
 	if err := md.Download(ctx, out); err != nil {

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -95,6 +95,12 @@ parameters:
   - name: MIGRATION_PLANNER_S3_ISO_FILENAME
     description: custom iso filename
     value: "custom-rhcos-live-iso.x86_64.iso"
+  - name: MIGRATION_PLANNER_ISO_SERVER_URL
+    description: URL of the internal ISO server
+    value: "http://migration-planner-iso-server"
+  - name: MIGRATION_PLANNER_ISO_SERVER_PORT
+    description: Port of the internal ISO server
+    value: "8080"
   - name: S3_SECRET_NAME
     description: secret name for s3 credentials
     value: "migration-planner-s3-creds"
@@ -404,6 +410,18 @@ objects:
           labels:
             app: migration-planner
         spec:
+          initContainers:
+            - name: wait-for-iso-server
+              image: curlimages/curl:8.10.1
+              command: [ "sh", "-ceu" ]
+              args:
+                - |
+                  i=0
+                  until curl -fsS -m 3 "${MIGRATION_PLANNER_ISO_SERVER_URL}:${MIGRATION_PLANNER_ISO_SERVER_PORT}/health" >/dev/null; do
+                    i=$((i+1))
+                    [ "$i" -ge 120 ] && echo "Timed out, proceeding without ISO server" >&2 && break
+                    sleep 2
+                  done
           containers:
             - name: envoy
               image: ${ENVOY_IMAGE}
@@ -533,16 +551,10 @@ objects:
                   value: ${MIGRATION_PLANNER_S3_BUCKET}
                 - name: MIGRATION_PLANNER_S3_ISO_FILENAME
                   value: ${MIGRATION_PLANNER_S3_ISO_FILENAME}
-                - name: MIGRATION_PLANNER_S3_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${S3_SECRET_NAME}
-                      key: access_key
-                - name: MIGRATION_PLANNER_S3_SECRET_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${S3_SECRET_NAME}
-                      key: secret_key
+                - name: MIGRATION_PLANNER_ISO_SERVER_URL
+                  value: ${MIGRATION_PLANNER_ISO_SERVER_URL}
+                - name: MIGRATION_PLANNER_ISO_SERVER_PORT
+                  value: ${MIGRATION_PLANNER_ISO_SERVER_PORT}
                 # DB Config values
                 - name: MIGRATION_PLANNER_MIGRATIONS_FOLDER
                   value: ${MIGRATION_PLANNER_MIGRATIONS_FOLDER}
@@ -589,3 +601,112 @@ objects:
             - name: envoy-unix-sockets
               emptyDir:
                 medium: Memory
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: migration-planner-iso-storage
+      labels:
+        app: migration-planner-iso-server
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      labels:
+        app: migration-planner-iso-server
+      name: migration-planner-iso-server
+    spec:
+      ports:
+        - name: iso-server
+          port: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+          protocol: TCP
+          targetPort: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+      selector:
+        app: migration-planner-iso-server
+  - kind: Deployment
+    apiVersion: apps/v1
+    metadata:
+      name: migration-planner-iso-server
+    spec:
+      replicas: 1
+      strategy:
+        type: Recreate
+      selector:
+        matchLabels:
+          app: migration-planner-iso-server
+      template:
+        metadata:
+          labels:
+            app: migration-planner-iso-server
+        spec:
+          containers:
+            - name: migration-planner-iso-server
+              image: ${MIGRATION_PLANNER_IMAGE}:${IMAGE_TAG}
+              imagePullPolicy: ${MIGRATION_PLANNER_API_IMAGE_PULL_POLICY}
+              command:
+                - /app/planner-api
+              args:
+                - init
+                - --listen
+                - --port
+                - "${MIGRATION_PLANNER_ISO_SERVER_PORT}"
+              ports:
+                - containerPort: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+                  name: iso-server
+              env:
+                - name: MIGRATION_PLANNER_ISO_PATH
+                  value: /iso-storage/rhcos-live-iso.x86_64.iso
+                - name: MIGRATION_PLANNER_ISO_URL
+                  value: ${MIGRATION_PLANNER_ISO_URL}
+                - name: MIGRATION_PLANNER_ISO_SHA256
+                  value: ${MIGRATION_PLANNER_ISO_SHA256}
+                - name: MIGRATION_PLANNER_LOG_LEVEL
+                  value: ${MIGRATION_PLANNER_LOG_LEVEL}
+                - name: MIGRATION_PLANNER_S3_ENDPOINT
+                  value: ${MIGRATION_PLANNER_S3_ENDPOINT}
+                - name: MIGRATION_PLANNER_S3_BUCKET
+                  value: ${MIGRATION_PLANNER_S3_BUCKET}
+                - name: MIGRATION_PLANNER_S3_ISO_FILENAME
+                  value: ${MIGRATION_PLANNER_S3_ISO_FILENAME}
+                - name: MIGRATION_PLANNER_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${S3_SECRET_NAME}
+                      key: access_key
+                - name: MIGRATION_PLANNER_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${S3_SECRET_NAME}
+                      key: secret_key
+              volumeMounts:
+                - name: iso-storage
+                  mountPath: /iso-storage
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 400m
+                  memory: 512Mi
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                periodSeconds: 30
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+                initialDelaySeconds: 30
+                timeoutSeconds: 5
+                periodSeconds: 10
+          volumes:
+            - name: iso-storage
+              persistentVolumeClaim:
+                claimName: migration-planner-iso-storage

--- a/internal/api_server/isoserver/server.go
+++ b/internal/api_server/isoserver/server.go
@@ -1,0 +1,108 @@
+package isoserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"go.uber.org/zap"
+)
+
+const (
+	gracefulShutdownTimeout = 5 * time.Second
+	GetIsoEndpoint          = "/iso"
+	HealthEndpoint          = "/health"
+)
+
+type IsoServer struct {
+	address  string
+	listener net.Listener
+	isoPath  string
+}
+
+func New(
+	listener net.Listener,
+	address, isoPath string,
+) *IsoServer {
+	return &IsoServer{
+		address:  address,
+		listener: listener,
+		isoPath:  isoPath,
+	}
+}
+
+func (s *IsoServer) Run(ctx context.Context) error {
+	zap.S().Named("iso_server").Info("Initializing iso server")
+
+	router := chi.NewRouter()
+
+	router.Use(
+		middleware.Recoverer,
+		middleware.Logger,
+	)
+
+	router.Get(HealthEndpoint, s.healthHandler)
+	router.Get(GetIsoEndpoint, s.serveIsoHandler)
+
+	srv := http.Server{Addr: s.address, Handler: router}
+
+	go func() {
+		<-ctx.Done()
+		zap.S().Named("iso_server").Infof("Shutdown signal received: %s", ctx.Err())
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		defer cancel()
+
+		srv.SetKeepAlivesEnabled(false)
+		_ = srv.Shutdown(ctxTimeout)
+	}()
+
+	zap.S().Named("iso_server").Infof("Listening on %s...", s.listener.Addr().String())
+	zap.S().Named("iso_server").Infof("Serving ISO from: %s", s.isoPath)
+	if err := srv.Serve(s.listener); err != nil && !errors.Is(err, net.ErrClosed) {
+		return err
+	}
+
+	return nil
+}
+
+func (s *IsoServer) healthHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(s.isoPath); err != nil {
+		zap.S().Named("iso_server").Warnf("Health check failed: ISO not available at %s", s.isoPath)
+		http.Error(w, "ISO file not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"healthy","iso_available":true}`))
+}
+
+func (s *IsoServer) serveIsoHandler(w http.ResponseWriter, r *http.Request) {
+	s.serveFile(w, r, s.isoPath)
+}
+
+func (s *IsoServer) serveFile(w http.ResponseWriter, r *http.Request, filePath string) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.Error(w, "File not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "File access error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", info.Size()))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filepath.Base(filePath)))
+
+	http.ServeFile(w, r, filePath)
+	zap.S().Named("iso_server").Infof("Served file: %s (%d bytes)", filePath, info.Size())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,9 @@ type svcConfig struct {
 	MigrationFolder      string `envconfig:"MIGRATION_PLANNER_MIGRATIONS_FOLDER" default:""`
 	OpaPoliciesFolder    string `envconfig:"MIGRATION_PLANNER_OPA_POLICIES_FOLDER" default:"/app/policies"`
 	S3                   S3
+	IsoServerBaseURL     string `envconfig:"MIGRATION_PLANNER_ISO_SERVER_URL" default:"http://127.0.0.1"`
+	IsoServerPort        string `envconfig:"MIGRATION_PLANNER_ISO_SERVER_PORT" default:"8080"`
+	IsoPath              string `envconfig:"MIGRATION_PLANNER_ISO_PATH" default:"rhcos-live-iso.x86_64.iso"`
 	RhcosImageName       string `envconfig:"MIGRATION_PLANNER_ISO_URL" default:""`
 	RhcosImageSha256     string `envconfig:"MIGRATION_PLANNER_ISO_SHA256" default:""`
 }

--- a/pkg/iso/http.go
+++ b/pkg/iso/http.go
@@ -39,22 +39,7 @@ func (h *HttpDownloader) Get(ctx context.Context, dst io.Writer) error {
 		totalSize = n
 	}
 
-	newCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	mw := newProgressWriter(newCtx, dst, totalSize)
-	imageHasher := newImageHasher(mw)
-
-	_, err = io.Copy(imageHasher, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	computedSum := imageHasher.Sum()
-	if h.imageSha256 != computedSum {
-		return fmt.Errorf("failed to download the image. wanted %q received %q", h.imageSha256, computedSum)
-	}
-
-	return nil
+	return DownloadWithValidation(ctx, resp.Body, dst, h.imageSha256, totalSize)
 }
 
 func (h *HttpDownloader) Type() string {

--- a/pkg/iso/initializer.go
+++ b/pkg/iso/initializer.go
@@ -3,25 +3,13 @@ package iso
 import (
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path"
-	"strings"
-	"time"
 
-	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
-
-const (
-	sentinelFile string = "planner-iso-download"
-)
-
-type waitResult struct {
-	Err error
-}
 
 type IsoDownloader interface {
 	Download(context.Context, io.WriteSeeker) error
@@ -35,78 +23,10 @@ func NewIsoInitializer(downloader IsoDownloader) *IsoInitializer {
 	return &IsoInitializer{downloader: downloader}
 }
 
-// Initialize ensures the target ISO file is available and valid by checking its SHA256 hash.
-// If the file exists and its SHA256 matches the expected value, no action is taken.
-// If the file is missing or has an incorrect hash, it downloads the new image to a temporary file,
-// then atomically replaces the existing file using intermediate naming to prevent corruption.
-// The method includes rollback logic and cleanup of temporary files to maintain system integrity.
-
-// The planner is typically deployed in Kubernetes with multiple replicas (usually 3+).
-// Using a persistent volume for ISO storage can create race conditions
-// when multiple pods attempt to download the same ISO file simultaneously.
-//
-// A simple solution is to retry downloads or fail until one pod succeeds.
-// However, repeated crashes may trigger false-positive monitoring alerts.
-// Therefore, a more elegant solution is to serialize pod dowload ops.
-// For that, each instance is looking for sentinelFile.
-// It waits until the sentinelFile is removed by the owner and start the process again.
-// If the another instance succeeded in downloading the iso return. If not start the process again.
+// Initialize always attempts to download a new ISO file.
+// If the download fails, the existing ISO file (if any) is kept unchanged.
+// If the download succeeds, the new ISO replaces the existing one.
 func (i *IsoInitializer) Initialize(ctx context.Context, targetIsoFile string, targetIsoSha256 string) error {
-	workingFolder := path.Dir(targetIsoFile)
-
-	waitCh := make(chan waitResult)
-	go func(ctx context.Context, c chan waitResult) {
-		for {
-			_, err := os.Stat(path.Join(workingFolder, sentinelFile))
-			if err != nil {
-				if errors.Is(err, os.ErrNotExist) {
-					c <- waitResult{}
-					return
-				}
-				c <- waitResult{Err: err}
-				return
-			}
-
-			// the sentinelFile is present on disk
-			// wait for the another instance to finish or for context to be canceled
-
-			t := time.NewTicker(2 * time.Second)
-			defer t.Stop()
-
-			zap.S().Debug("waiting for another instance to download iso")
-
-			select {
-			case <-ctx.Done():
-				c <- waitResult{Err: ctx.Err()}
-				return
-			case <-t.C:
-			}
-		}
-	}(ctx, waitCh)
-
-	result := <-waitCh
-	if result.Err != nil {
-		return result.Err
-	}
-
-	statErr := i.verifyIso(targetIsoFile, targetIsoSha256)
-	if statErr == nil {
-		return nil
-	}
-
-	// touch the sentinelFile
-	sf, err := os.Create(path.Join(workingFolder, sentinelFile))
-	if err != nil {
-		return fmt.Errorf("failed to create sentinel file: %w", err)
-	}
-	sf.Close()
-	defer func() {
-		_ = os.Remove(path.Join(workingFolder, sentinelFile))
-	}()
-
-	zap.S().Debugw("failed to verify the integrity of the existing image", "error", statErr, "target iso", targetIsoFile, "target sha256", targetIsoSha256)
-
-	// first try to download the new image to temporary file
 	tempIsoFile, err := os.CreateTemp(path.Dir(targetIsoFile), "iso-image")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary iso file: %w", err)
@@ -117,33 +37,18 @@ func (i *IsoInitializer) Initialize(ctx context.Context, targetIsoFile string, t
 	}()
 
 	if err := i.downloader.Download(ctx, tempIsoFile); err != nil {
-		tempIsoFile.Close()
+		_ = tempIsoFile.Close()
 		return fmt.Errorf("failed to write the image to the temporary iso file: %w", err)
 	}
-	tempIsoFile.Close()
+	_ = tempIsoFile.Close()
 
-	// if targetIsoFile does not exists, just move the new the targetIsoFile
-	if errors.Is(statErr, os.ErrNotExist) {
-		return os.Rename(tempIsoFile.Name(), targetIsoFile)
+	if err := i.verifyIso(tempIsoFile.Name(), targetIsoSha256); err != nil {
+		return fmt.Errorf("downloaded ISO failed verification: %w", err)
 	}
 
-	intermediateFilename := i.createIntermediateFilename(targetIsoFile)
+	zap.S().Infof("replacing old ISO %s with new ISO %s", targetIsoFile, tempIsoFile.Name())
 
-	if err := os.Rename(targetIsoFile, intermediateFilename); err != nil {
-		return fmt.Errorf("failed to rename the old image iso: %w", err)
-	}
-
-	if err := os.Rename(tempIsoFile.Name(), targetIsoFile); err != nil {
-		// try to rollback the old image
-		return os.Rename(intermediateFilename, targetIsoFile)
-	}
-
-	// safe to remove the oldfile
-	if err := os.Remove(intermediateFilename); err != nil {
-		zap.S().Warnw("failed to remove the old iso image from storage", "error", err)
-	}
-
-	return nil
+	return os.Rename(tempIsoFile.Name(), targetIsoFile)
 }
 
 func (i *IsoInitializer) verifyIso(targetIsoFile, targetIsoSha256 string) error {
@@ -170,10 +75,4 @@ func (i *IsoInitializer) verifyIso(targetIsoFile, targetIsoSha256 string) error 
 	}
 
 	return nil
-}
-
-func (i *IsoInitializer) createIntermediateFilename(targetIsoFile string) string {
-	baseName := strings.TrimSuffix(path.Base(targetIsoFile), path.Ext(targetIsoFile))
-	ext := path.Ext(targetIsoFile)
-	return path.Join(path.Dir(targetIsoFile), fmt.Sprintf("%s%x%s", baseName, uuid.NewString()[:6], ext))
 }

--- a/pkg/iso/initializer_test.go
+++ b/pkg/iso/initializer_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/kubev2v/migration-planner/pkg/iso"
@@ -66,10 +65,10 @@ var _ = Describe("iso initializer", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should not download anything and preserve the original file", func() {
+		It("should download always a new ISO file", func() {
 			err := initializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
 			Expect(err).To(BeNil())
-			Expect(testDownloader.hasBeenCalled).To(BeFalse())
+			Expect(testDownloader.hasBeenCalled).To(BeTrue())
 
 			// Verify the original file still exists and contains the correct data
 			data, err := os.ReadFile(targetIsoFile)
@@ -175,93 +174,6 @@ var _ = Describe("iso initializer", func() {
 		})
 	})
 
-	Context("when multiple intializer are executed", func() {
-		It("the first initializer should download the iso", func() {
-			testDownloader1 := &testIsoDownloader{
-				dataToWrite: testData,
-			}
-			firstInitializer := iso.NewIsoInitializer(testDownloader1)
-			testDownloader2 := &testIsoDownloader{
-				dataToWrite: testData,
-			}
-			secondInitializer := iso.NewIsoInitializer(testDownloader2)
-
-			var wait sync.WaitGroup
-			wait.Add(2)
-			go func() {
-				err := firstInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
-				Expect(err).To(BeNil())
-				wait.Done()
-			}()
-
-			// the second should not start the download
-			go func() {
-				<-time.After(1 * time.Second)
-				err := secondInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
-				Expect(err).To(BeNil())
-				wait.Done()
-			}()
-			wait.Wait()
-
-			Expect(testDownloader1.hasBeenCalled).To(BeTrue())
-			Expect(testDownloader2.hasBeenCalled).To(BeFalse())
-			// Verify file was created with correct content
-			data, err := os.ReadFile(targetIsoFile)
-			Expect(err).To(BeNil())
-			Expect(data).To(Equal(testData))
-
-			// in download folder, we should have only the iso.
-			entries, err := os.ReadDir(tempDir)
-			Expect(err).To(BeNil())
-			Expect(entries).To(HaveLen(1))
-		})
-
-		It("the first initializer fails but the second downloads the iso", func() {
-			testDownloader1 := &testIsoDownloader{
-				dataToWrite:       testData,
-				shouldReturnError: true,
-			}
-			firstInitializer := iso.NewIsoInitializer(testDownloader1)
-			testDownloader2 := &testIsoDownloader{
-				dataToWrite: testData,
-			}
-			secondInitializer := iso.NewIsoInitializer(testDownloader2)
-
-			var wait sync.WaitGroup
-			wait.Add(2)
-
-			var firstErr error
-			go func() {
-				firstErr = firstInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoFile)
-				wait.Done()
-			}()
-
-			var secondErr error
-			go func() {
-				<-time.After(1 * time.Second)
-				secondErr = secondInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
-				wait.Done()
-			}()
-			wait.Wait()
-
-			Expect(secondErr).To(BeNil())
-			Expect(firstErr).NotTo(BeNil())
-
-			// Both initializers should be called
-			Expect(testDownloader1.hasBeenCalled).To(BeTrue())
-			Expect(testDownloader2.hasBeenCalled).To(BeTrue())
-
-			// Verify file was created with correct content
-			data, err := os.ReadFile(targetIsoFile)
-			Expect(err).To(BeNil())
-			Expect(data).To(Equal(testData))
-
-			// in download folder, we should have only the iso.
-			entries, err := os.ReadDir(tempDir)
-			Expect(err).To(BeNil())
-			Expect(entries).To(HaveLen(1))
-		})
-	})
 })
 
 // testIsoDownloader is a simple implementation of IsoDownloader for testing

--- a/pkg/iso/isoserver.go
+++ b/pkg/iso/isoserver.go
@@ -1,0 +1,98 @@
+package iso
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/kubev2v/migration-planner/internal/api_server/isoserver"
+)
+
+type ServerDownloader struct {
+	baseServerURL string
+	imageSha256   string
+	timeout       time.Duration
+}
+
+func NewIsoServerDownloader(baseServerURL, imageSha256 string) *ServerDownloader {
+	return &ServerDownloader{
+		baseServerURL: baseServerURL,
+		imageSha256:   imageSha256,
+		timeout:       time.Minute,
+	}
+}
+
+func (i *ServerDownloader) Get(ctx context.Context, dst io.Writer) error {
+	client := &http.Client{
+		Timeout: i.timeout,
+	}
+
+	u, err := url.Parse(i.baseServerURL)
+	if err != nil {
+		return fmt.Errorf("invalid base URL: %w", err)
+	}
+	u.Path = path.Join(u.Path, isoserver.GetIsoEndpoint)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for ISO server: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to fetch ISO from server %q: %w", u.String(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ISO server returned status %d for %q", resp.StatusCode, u.String())
+	}
+
+	totalSize := int64(0)
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		if n, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
+			totalSize = n
+		}
+	}
+
+	return DownloadWithValidation(ctx, resp.Body, dst, i.imageSha256, totalSize)
+}
+
+// HealthCheck verifies if the ISO server is available and has the required ISO
+func (i *ServerDownloader) HealthCheck(ctx context.Context) error {
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	u, err := url.Parse(i.baseServerURL)
+	if err != nil {
+		return fmt.Errorf("invalid base URL: %w", err)
+	}
+	u.Path = path.Join(u.Path, isoserver.HealthEndpoint)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create health check request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("ISO server health check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ISO server health check returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (i *ServerDownloader) Type() string {
+	return "iso-server"
+}


### PR DESCRIPTION
## Summary by Sourcery

Implement a rolling ISO initializer with an embedded HTTP server and client/server downloaders, refactor the init command, and update Kubernetes manifests to deploy the ISO server.

New Features:
- Add an ISO server component exposing /iso and /health endpoints to serve the initialized RHCOS ISO
- Extend the init command with --listen and --port flags to optionally start the ISO server
- Introduce a ServerDownloader that fetches the ISO from the internal server with health checks in the run workflow

Enhancements:
- Centralize download and SHA256 validation logic into DownloadWithValidation
- Refactor the init command to use InitOptions and NewCmdInit with flag binding
- Update HTTP and Minio downloaders to leverage the shared validation function

Deployment:
- Add PersistentVolumeClaim, Service, and Deployment for the ISO server in Kubernetes templates
- Expose MIGRATION_PLANNER_ISO_SERVER_URL as a new environment variable in manifests