### PR TITLE
ECOPROJECT-3200 | feat: Implement a rolling iso image initializer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ init:
 	MIGRATION_PLANNER_ISO_SHA256=$(MIGRATION_PLANNER_ISO_SHA256) \
 	./bin/planner-api init
 
-run:
+run: image
 	MIGRATION_PLANNER_MIGRATIONS_FOLDER=$(CURDIR)/pkg/migrations/sql \
 	MIGRATION_PLANNER_OPA_POLICIES_FOLDER=$(MIGRATION_PLANNER_OPA_POLICIES_FOLDER) \
 	./bin/planner-api run
@@ -118,10 +118,12 @@ run-agent:
 
 image:
 ifeq ($(DOWNLOAD_RHCOS), true)
-	curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
+	@if [ ! -f rhcos-live-iso.x86_64.iso ]; then \
+		curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso; \
+	fi
 endif
 
-build: bin image
+build: bin
 	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/...
 
 build-api: bin

--- a/cmd/planner-api/init.go
+++ b/cmd/planner-api/init.go
@@ -2,57 +2,101 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/kubev2v/migration-planner/internal/config"
-	"github.com/kubev2v/migration-planner/internal/util"
-	"github.com/kubev2v/migration-planner/pkg/iso"
+	"github.com/kubev2v/migration-planner/internal/api_server/isoserver"
 	"github.com/kubev2v/migration-planner/pkg/log"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/kubev2v/migration-planner/internal/config"
+	"github.com/kubev2v/migration-planner/pkg/iso"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize RHCOS ISO for the migration planner",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		defer zap.S().Info("ISO initialization completed")
+type InitOptions struct {
+	Serve bool
+	Port  string
+}
 
-		cfg, err := config.New()
-		if err != nil {
-			zap.S().Fatalw("reading configuration", "error", err)
-		}
+func DefaultInitOptions() *InitOptions {
+	return &InitOptions{
+		Serve: false,
+	}
+}
 
-		logLvl, err := zap.ParseAtomicLevel(cfg.Service.LogLevel)
-		if err != nil {
-			logLvl = zap.NewAtomicLevelAt(zapcore.InfoLevel)
-		}
+func NewCmdInit() *cobra.Command {
+	o := DefaultInitOptions()
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize RHCOS ISO for the migration planner",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.New()
+			if err != nil {
+				return fmt.Errorf("reading config: %w", err)
+			}
+			_, undo := setupLogger(cfg.Service.LogLevel)
+			defer undo()
+			zap.S().Info("Starting ISO initialization...")
 
-		logger := log.InitLog(logLvl)
-		defer func() { _ = logger.Sync() }()
+			ctx, cancel := setupSignalContext()
+			defer cancel()
 
-		undo := zap.ReplaceGlobals(logger)
-		defer undo()
+			// Initialize ISOs
+			zap.S().Info("Initializing RHCOS ISO")
+			isoInitializer := newIsoInitializer(cfg)
+			if err := isoInitializer.Initialize(ctx, cfg.Service.IsoPath, cfg.Service.RhcosImageSha256); err != nil {
+				zap.S().Fatalw("failed to initialize iso", "error", err)
+			}
 
-		zap.S().Info("Starting ISO initialization...")
+			if o.Serve {
+				return serveISO(ctx, o.Port, cfg.Service.IsoPath)
+			}
+			return nil
+		},
+	}
 
-		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGQUIT)
-		defer cancel()
+	cmd.SilenceUsage = true
+	o.Bind(cmd.Flags())
+	return cmd
+}
 
-		// Initialize ISOs
-		zap.S().Info("Initializing RHCOS ISO")
-		isoInitializer := newIsoInitializer(cfg)
-		targetIsoFile := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
-		if err := isoInitializer.Initialize(ctx, targetIsoFile, cfg.Service.RhcosImageSha256); err != nil {
-			zap.S().Fatalw("failed to initialize iso", "error", err)
-		}
-		zap.S().Info("RHCOS ISO initialized successfully")
+func setupLogger(levelStr string) (*zap.Logger, func()) {
+	level, err := zap.ParseAtomicLevel(levelStr)
+	if err != nil {
+		level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+	}
+	logger := log.InitLog(level)
+	undo := zap.ReplaceGlobals(logger)
+	return logger, func() { _ = logger.Sync(); undo() }
+}
 
-		return nil
-	},
+func setupSignalContext() (context.Context, func()) {
+	ctx, cancel := signal.NotifyContext(
+		context.Background(),
+		os.Interrupt, syscall.SIGHUP,
+		syscall.SIGTERM, syscall.SIGQUIT,
+	)
+	return ctx, cancel
+}
+
+func serveISO(ctx context.Context, port, isoPath string) error {
+	addr := fmt.Sprintf("0.0.0.0:%s", port)
+	ln, err := newListener(addr)
+	if err != nil {
+		return fmt.Errorf("creating listener: %w", err)
+	}
+	server := isoserver.New(ln, addr, isoPath)
+	return server.Run(ctx)
+}
+
+func (o *InitOptions) Bind(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.Serve, "listen", false, "listen to serve the iso file")
+	fs.StringVarP(&o.Port, "port", "p", "8080", "Port to listen on")
 }
 
 func newIsoInitializer(cfg *config.Config) *iso.IsoInitializer {

--- a/cmd/planner-api/root.go
+++ b/cmd/planner-api/root.go
@@ -11,7 +11,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(NewCmdInit())
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(runCmd)
 

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -13,8 +15,6 @@ import (
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/opa"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/internal/util"
-	"github.com/kubev2v/migration-planner/pkg/iso"
 	"github.com/kubev2v/migration-planner/pkg/log"
 	"github.com/kubev2v/migration-planner/pkg/metrics"
 	"github.com/kubev2v/migration-planner/pkg/migrations"
@@ -68,12 +68,12 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		// Initialize ISOs
-		zap.S().Info("Initializing RHCOS ISO")
-		if err := initializeIso(context.TODO(), cfg); err != nil {
-			zap.S().Fatalw("failed to initilized iso", "error", err)
+		// The migration planner API expects the RHCOS ISO to be on disk
+		if err := validateIso(cfg.Service.IsoPath); err != nil {
+			zap.S().Fatalw("validate iso", "error", err)
+			return err
 		}
-		zap.S().Info("RHCOS ISO initialized")
+		zap.S().Info("RHCOS ISO exists. Proceeding...")
 
 		// Initialize OPA validator for policy validation
 		zap.S().Info("initializing OPA validator...")
@@ -151,42 +151,14 @@ func newListener(address string) (net.Listener, error) {
 	return net.Listen("tcp", address)
 }
 
-func initializeIso(ctx context.Context, cfg *config.Config) error {
-	// Check if ISO already exists:
-	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
-	if _, err := os.Stat(isoPath); err == nil {
-		return nil
-	}
-
-	out, err := os.Create(isoPath)
-	if err != nil {
+func validateIso(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("RHCOS ISO not found at path: %s", path)
+		} else if errors.Is(err, os.ErrPermission) {
+			return fmt.Errorf("permission denied for file: %s", path)
+		}
 		return err
 	}
-	defer out.Close()
-
-	md := iso.NewDownloaderManager()
-
-	minio, err := iso.NewMinioDownloader(
-		iso.WithEndpoint(cfg.Service.S3.Endpoint),
-		iso.WithBucket(cfg.Service.S3.Bucket),
-		iso.WithAccessKey(cfg.Service.S3.AccessKey),
-		iso.WithSecretKey(cfg.Service.S3.SecretKey),
-		iso.WithImage(cfg.Service.S3.IsoFileName, cfg.Service.RhcosImageSha256),
-	)
-	if err == nil {
-		md.Register(minio)
-	} else {
-		zap.S().Errorw("failed to create minio downloader", "error", err)
-	}
-
-	// register the default downloader of the official RHCOS image.
-	md.Register(iso.NewHttpDownloader(cfg.Service.RhcosImageName, cfg.Service.RhcosImageSha256))
-
-	if err := md.Download(ctx, out); err != nil {
-		// Remove the file from disk to allow the planner to retry the image download after restart.
-		_ = os.Remove(isoPath)
-		return err
-	}
-
 	return nil
 }

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -19,6 +19,12 @@ parameters:
     value: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-4.19.0-x86_64-live-iso.x86_64.iso
   - name: MIGRATION_PLANNER_ISO_SHA256
     value: 6a9cf9df708e014a2b44f372ab870f873cf2db5685f9ef4518f52caa36160c36
+  - name: MIGRATION_PLANNER_ISO_SERVER_URL
+    description: URL of the internal ISO server
+    value: "http://migration-planner-iso-server"
+  - name: MIGRATION_PLANNER_ISO_SERVER_PORT
+    description: Port of the internal ISO server
+    value: "8080"
   - name: MIGRATION_PLANNER_URL
     description: The API URL of the migration assessment
     required: true
@@ -404,6 +410,26 @@ objects:
           labels:
             app: migration-planner
         spec:
+          initContainers:
+            - name: wait-for-iso-server
+              image: curlimages/curl:8.10.1
+              command: [ "sh", "-ceu" ]
+              args:
+                - |
+                  i=0
+                  until curl -fsS -I -m 3 "${MIGRATION_PLANNER_ISO_SERVER_URL}:${MIGRATION_PLANNER_ISO_SERVER_PORT}/iso" >/dev/null; do
+                    i=$((i+1))
+                    if [ "$i" -ge 180 ]; then
+                      echo "Timed out waiting for ISO server" >&2
+                      exit 1
+                    fi
+                    sleep 2
+                  done
+                  echo "ISO server is ready, downloading ISO file..."
+                  curl -fsS -o "${MIGRATION_PLANNER_ISO_PATH}" "${MIGRATION_PLANNER_ISO_SERVER_URL}:${MIGRATION_PLANNER_ISO_SERVER_PORT}/iso"
+              volumeMounts:
+                - name: iso-storage
+                  mountPath: /iso
           containers:
             - name: envoy
               image: ${ENVOY_IMAGE}
@@ -493,10 +519,6 @@ objects:
                   value: ${INSECURE_REGISTRY}
                 - name: MIGRATION_PLANNER_ISO_PATH
                   value: ${MIGRATION_PLANNER_ISO_PATH}
-                - name: MIGRATION_PLANNER_ISO_URL
-                  value: ${MIGRATION_PLANNER_ISO_URL}
-                - name: MIGRATION_PLANNER_ISO_SHA256
-                  value: ${MIGRATION_PLANNER_ISO_SHA256}
                 # Svc Config values
                 - name: MIGRATION_PLANNER_ADDRESS
                   value: ${MIGRATION_PLANNER_ADDRESS}
@@ -527,22 +549,6 @@ objects:
                   value: ${MIGRATION_PLANNER_JWK_URL}
                 - name: MIGRATION_PLANNER_AGENT_AUTH_ENABLED
                   value: ${MIGRATION_PLANNER_AGENT_AUTH_ENABLED}
-                - name: MIGRATION_PLANNER_S3_ENDPOINT
-                  value: ${MIGRATION_PLANNER_S3_ENDPOINT}
-                - name: MIGRATION_PLANNER_S3_BUCKET
-                  value: ${MIGRATION_PLANNER_S3_BUCKET}
-                - name: MIGRATION_PLANNER_S3_ISO_FILENAME
-                  value: ${MIGRATION_PLANNER_S3_ISO_FILENAME}
-                - name: MIGRATION_PLANNER_S3_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${S3_SECRET_NAME}
-                      key: access_key
-                - name: MIGRATION_PLANNER_S3_SECRET_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${S3_SECRET_NAME}
-                      key: secret_key
                 # DB Config values
                 - name: MIGRATION_PLANNER_MIGRATIONS_FOLDER
                   value: ${MIGRATION_PLANNER_MIGRATIONS_FOLDER}
@@ -589,3 +595,112 @@ objects:
             - name: envoy-unix-sockets
               emptyDir:
                 medium: Memory
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: migration-planner-iso-storage
+      labels:
+        app: migration-planner-iso-server
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 5Gi
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      labels:
+        app: migration-planner-iso-server
+      name: migration-planner-iso-server
+    spec:
+      ports:
+        - name: iso-server
+          port: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+          protocol: TCP
+          targetPort: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+      selector:
+        app: migration-planner-iso-server
+  - kind: Deployment
+    apiVersion: apps/v1
+    metadata:
+      name: migration-planner-iso-server
+    spec:
+      replicas: 1
+      strategy:
+        type: Recreate
+      selector:
+        matchLabels:
+          app: migration-planner-iso-server
+      template:
+        metadata:
+          labels:
+            app: migration-planner-iso-server
+        spec:
+          containers:
+            - name: migration-planner-iso-server
+              image: ${MIGRATION_PLANNER_IMAGE}:${IMAGE_TAG}
+              imagePullPolicy: ${MIGRATION_PLANNER_API_IMAGE_PULL_POLICY}
+              command:
+                - /app/planner-api
+              args:
+                - init
+                - --listen
+                - --port
+                - "${MIGRATION_PLANNER_ISO_SERVER_PORT}"
+              ports:
+                - containerPort: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+                  name: iso-server
+              env:
+                - name: MIGRATION_PLANNER_ISO_PATH
+                  value: /iso-storage/rhcos-live-iso.x86_64.iso
+                - name: MIGRATION_PLANNER_ISO_URL
+                  value: ${MIGRATION_PLANNER_ISO_URL}
+                - name: MIGRATION_PLANNER_ISO_SHA256
+                  value: ${MIGRATION_PLANNER_ISO_SHA256}
+                - name: MIGRATION_PLANNER_LOG_LEVEL
+                  value: ${MIGRATION_PLANNER_LOG_LEVEL}
+                - name: MIGRATION_PLANNER_S3_ENDPOINT
+                  value: ${MIGRATION_PLANNER_S3_ENDPOINT}
+                - name: MIGRATION_PLANNER_S3_BUCKET
+                  value: ${MIGRATION_PLANNER_S3_BUCKET}
+                - name: MIGRATION_PLANNER_S3_ISO_FILENAME
+                  value: ${MIGRATION_PLANNER_S3_ISO_FILENAME}
+                - name: MIGRATION_PLANNER_S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${S3_SECRET_NAME}
+                      key: access_key
+                - name: MIGRATION_PLANNER_S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${S3_SECRET_NAME}
+                      key: secret_key
+              volumeMounts:
+                - name: iso-storage
+                  mountPath: /iso-storage
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
+                limits:
+                  cpu: 400m
+                  memory: 512Mi
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                periodSeconds: 30
+              readinessProbe:
+                httpGet:
+                  path: /healthz
+                  port: ${{MIGRATION_PLANNER_ISO_SERVER_PORT}}
+                initialDelaySeconds: 60
+                timeoutSeconds: 5
+                periodSeconds: 30
+          volumes:
+            - name: iso-storage
+              persistentVolumeClaim:
+                claimName: migration-planner-iso-storage

--- a/internal/agent/collector/vsphere.go
+++ b/internal/agent/collector/vsphere.go
@@ -661,21 +661,22 @@ func getDatastores(hosts *[]vspheremodel.Host, collector *vsphere.Collector) []a
 		return nil
 	}
 
-	// Create datastore-to-hostID mapping once for better performance
-	datastoreToHostID := make(map[string]string)
+	// Create datastore-to-hostIDs mapping once for better performance
+	datastoreToHostIDs := make(map[string][]string)
 	for _, host := range *hosts {
 		for _, dsRef := range host.Datastores {
-			datastoreToHostID[dsRef.ID] = host.ID
+			datastoreToHostIDs[dsRef.ID] = append(datastoreToHostIDs[dsRef.ID], host.ID)
 		}
 	}
 
 	res := []apiplanner.Datastore{}
 	for _, ds := range *datastores {
 		dsVendor, dsModel, dsProtocol := findDataStoreInfo(*hosts, ds.BackingDevicesNames)
-		hostID := datastoreToHostID[ds.ID]
+		hostIDs := datastoreToHostIDs[ds.ID]
 		var hostIDPtr *string
-		if hostID != "" {
-			hostIDPtr = &hostID
+		if len(hostIDs) > 0 {
+			joined := strings.Join(hostIDs, ", ")
+			hostIDPtr = &joined
 		}
 
 		res = append(res, apiplanner.Datastore{

--- a/internal/api_server/isoserver/server.go
+++ b/internal/api_server/isoserver/server.go
@@ -1,0 +1,114 @@
+package isoserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"go.uber.org/zap"
+)
+
+const (
+	gracefulShutdownTimeout = 5 * time.Second
+	IsoEndpoint             = "/iso"
+	HealthEndpoint          = "/healthz"
+)
+
+type IsoServer struct {
+	address  string
+	listener net.Listener
+	isoPath  string
+}
+
+func New(
+	listener net.Listener,
+	address, isoPath string,
+) *IsoServer {
+	return &IsoServer{
+		address:  address,
+		listener: listener,
+		isoPath:  isoPath,
+	}
+}
+
+func (s *IsoServer) Run(ctx context.Context) error {
+	zap.S().Named("iso_server").Info("Initializing iso server")
+
+	router := chi.NewRouter()
+
+	router.Use(
+		middleware.Recoverer,
+		middleware.Logger,
+	)
+
+	router.Get(HealthEndpoint, s.healthHandler)
+	router.Get(IsoEndpoint, s.serveIsoHandler)
+	router.Head(IsoEndpoint, s.isoHeadHandler)
+
+	srv := http.Server{Addr: s.address, Handler: router}
+
+	go func() {
+		<-ctx.Done()
+		zap.S().Named("iso_server").Infof("Shutdown signal received: %s", ctx.Err())
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		defer cancel()
+
+		srv.SetKeepAlivesEnabled(false)
+		_ = srv.Shutdown(ctxTimeout)
+	}()
+
+	zap.S().Named("iso_server").Infof("Listening on %s...", s.listener.Addr().String())
+	zap.S().Named("iso_server").Infof("Serving ISO from: %s", s.isoPath)
+	if err := srv.Serve(s.listener); err != nil && !errors.Is(err, net.ErrClosed) {
+		return err
+	}
+
+	return nil
+}
+
+func (s *IsoServer) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (s *IsoServer) isoHeadHandler(w http.ResponseWriter, r *http.Request) {
+	if _, err := os.Stat(s.isoPath); err != nil {
+		zap.S().Named("iso_server").Warnf("ISO HEAD check failed: ISO not available at %s", s.isoPath)
+		http.Error(w, "ISO file not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *IsoServer) serveIsoHandler(w http.ResponseWriter, r *http.Request) {
+	s.serveFile(w, r, s.isoPath)
+}
+
+func (s *IsoServer) serveFile(w http.ResponseWriter, r *http.Request, filePath string) {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			http.Error(w, "File not found", http.StatusNotFound)
+		} else {
+			http.Error(w, "File access error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", info.Size()))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filepath.Base(filePath)))
+
+	http.ServeFile(w, r, filePath)
+	zap.S().Named("iso_server").Infof("Served file: %s (%d bytes)", filePath, info.Size())
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type svcConfig struct {
 	MigrationFolder      string `envconfig:"MIGRATION_PLANNER_MIGRATIONS_FOLDER" default:""`
 	OpaPoliciesFolder    string `envconfig:"MIGRATION_PLANNER_OPA_POLICIES_FOLDER" default:"/app/policies"`
 	S3                   S3
+	IsoPath              string `envconfig:"MIGRATION_PLANNER_ISO_PATH" default:"rhcos-live-iso.x86_64.iso"`
 	RhcosImageName       string `envconfig:"MIGRATION_PLANNER_ISO_URL" default:""`
 	RhcosImageSha256     string `envconfig:"MIGRATION_PLANNER_ISO_SHA256" default:""`
 }

--- a/pkg/iso/http.go
+++ b/pkg/iso/http.go
@@ -39,22 +39,7 @@ func (h *HttpDownloader) Get(ctx context.Context, dst io.Writer) error {
 		totalSize = n
 	}
 
-	newCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	mw := newProgressWriter(newCtx, dst, totalSize)
-	imageHasher := newImageHasher(mw)
-
-	_, err = io.Copy(imageHasher, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	computedSum := imageHasher.Sum()
-	if h.imageSha256 != computedSum {
-		return fmt.Errorf("failed to download the image. wanted %q received %q", h.imageSha256, computedSum)
-	}
-
-	return nil
+	return DownloadWithValidation(ctx, resp.Body, dst, h.imageSha256, totalSize)
 }
 
 func (h *HttpDownloader) Type() string {

--- a/pkg/iso/initializer_test.go
+++ b/pkg/iso/initializer_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"github.com/kubev2v/migration-planner/pkg/iso"
@@ -175,93 +174,6 @@ var _ = Describe("iso initializer", func() {
 		})
 	})
 
-	Context("when multiple intializer are executed", func() {
-		It("the first initializer should download the iso", func() {
-			testDownloader1 := &testIsoDownloader{
-				dataToWrite: testData,
-			}
-			firstInitializer := iso.NewIsoInitializer(testDownloader1)
-			testDownloader2 := &testIsoDownloader{
-				dataToWrite: testData,
-			}
-			secondInitializer := iso.NewIsoInitializer(testDownloader2)
-
-			var wait sync.WaitGroup
-			wait.Add(2)
-			go func() {
-				err := firstInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
-				Expect(err).To(BeNil())
-				wait.Done()
-			}()
-
-			// the second should not start the download
-			go func() {
-				<-time.After(1 * time.Second)
-				err := secondInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
-				Expect(err).To(BeNil())
-				wait.Done()
-			}()
-			wait.Wait()
-
-			Expect(testDownloader1.hasBeenCalled).To(BeTrue())
-			Expect(testDownloader2.hasBeenCalled).To(BeFalse())
-			// Verify file was created with correct content
-			data, err := os.ReadFile(targetIsoFile)
-			Expect(err).To(BeNil())
-			Expect(data).To(Equal(testData))
-
-			// in download folder, we should have only the iso.
-			entries, err := os.ReadDir(tempDir)
-			Expect(err).To(BeNil())
-			Expect(entries).To(HaveLen(1))
-		})
-
-		It("the first initializer fails but the second downloads the iso", func() {
-			testDownloader1 := &testIsoDownloader{
-				dataToWrite:       testData,
-				shouldReturnError: true,
-			}
-			firstInitializer := iso.NewIsoInitializer(testDownloader1)
-			testDownloader2 := &testIsoDownloader{
-				dataToWrite: testData,
-			}
-			secondInitializer := iso.NewIsoInitializer(testDownloader2)
-
-			var wait sync.WaitGroup
-			wait.Add(2)
-
-			var firstErr error
-			go func() {
-				firstErr = firstInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoFile)
-				wait.Done()
-			}()
-
-			var secondErr error
-			go func() {
-				<-time.After(1 * time.Second)
-				secondErr = secondInitializer.Initialize(context.TODO(), targetIsoFile, targetIsoSha256)
-				wait.Done()
-			}()
-			wait.Wait()
-
-			Expect(secondErr).To(BeNil())
-			Expect(firstErr).NotTo(BeNil())
-
-			// Both initializers should be called
-			Expect(testDownloader1.hasBeenCalled).To(BeTrue())
-			Expect(testDownloader2.hasBeenCalled).To(BeTrue())
-
-			// Verify file was created with correct content
-			data, err := os.ReadFile(targetIsoFile)
-			Expect(err).To(BeNil())
-			Expect(data).To(Equal(testData))
-
-			// in download folder, we should have only the iso.
-			entries, err := os.ReadDir(tempDir)
-			Expect(err).To(BeNil())
-			Expect(entries).To(HaveLen(1))
-		})
-	})
 })
 
 // testIsoDownloader is a simple implementation of IsoDownloader for testing


### PR DESCRIPTION
## Summary by Sourcery

Implement an internal ISO server and client mechanism for RHCOS image initialization, simplify download and verification logic, refactor the init CLI and downloader components, and update Kubernetes manifests to integrate the new server-based workflow.

New Features:
- Deploy an internal ISO server in Kubernetes with PVC, Service, and Deployment
- Add a `--listen` flag to the init command to serve the ISO via HTTP
- Introduce DownloadWithValidation middleware for streaming downloads with SHA256 verification
- Introduce IsoServerDownloader client to fetch ISO from the internal server

Enhancements:
- Simplify IsoInitializer to always download a new ISO and atomically replace the old file on success
- Refactor init command into a cobra `NewCmdInit` with dedicated logger and signal handling setup
- Refactor HTTP and Minio downloaders to use DownloadWithValidation and remove duplicated hashing logic
- Update run command to prefer the ISO server downloader with health-check fallback before HTTP retrieval

Deployment:
- Update Helm service template to configure and wait for the ISO server and remove direct S3 credential injection for ISO download
- Add environment variables for ISO server URL and port

Tests:
- Update iso initializer tests to assert downloads occur on every run and remove concurrency coordination scenarios