### PR TITLE
ECOPROJECT-3200 | feat: Implement a flow for initalizing the RHCOS ISO

Signed-off-by: Aviel Segev <asegev@redhat.com>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ init:
 	MIGRATION_PLANNER_ISO_SHA256=$(MIGRATION_PLANNER_ISO_SHA256) \
 	./bin/planner-api init
 
-run:
+run: image
 	MIGRATION_PLANNER_MIGRATIONS_FOLDER=$(CURDIR)/pkg/migrations/sql \
 	MIGRATION_PLANNER_OPA_POLICIES_FOLDER=$(MIGRATION_PLANNER_OPA_POLICIES_FOLDER) \
 	./bin/planner-api run
@@ -118,10 +118,12 @@ run-agent:
 
 image:
 ifeq ($(DOWNLOAD_RHCOS), true)
-	curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso
+	@if [ ! -f rhcos-live-iso.x86_64.iso ]; then \
+    	curl --silent -C - -O https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-live-iso.x86_64.iso; \
+    fi
 endif
 
-build: bin image
+build: bin
 	go build -buildvcs=false $(GO_BUILD_FLAGS) -o $(GOBIN) ./cmd/...
 
 build-api: bin

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -69,7 +69,7 @@ var runCmd = &cobra.Command{
 		}
 
 		// The migration planner API expects the RHCOS ISO to be on disk
-		if err := validateIso(cfg.Service.IsoPath); err != nil {
+		if err := ensureIsoExist(cfg.Service.IsoPath); err != nil {
 			zap.S().Fatalw("validate iso", "error", err)
 			return err
 		}
@@ -150,7 +150,7 @@ func newListener(address string) (net.Listener, error) {
 	return net.Listen("tcp", address)
 }
 
-func validateIso(path string) error {
+func ensureIsoExist(path string) error {
 	if _, err := os.Stat(path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("RHCOS ISO not found at path: %s", path)

--- a/cmd/planner-api/run.go
+++ b/cmd/planner-api/run.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -13,8 +15,6 @@ import (
 	"github.com/kubev2v/migration-planner/internal/config"
 	"github.com/kubev2v/migration-planner/internal/opa"
 	"github.com/kubev2v/migration-planner/internal/store"
-	"github.com/kubev2v/migration-planner/internal/util"
-	"github.com/kubev2v/migration-planner/pkg/iso"
 	"github.com/kubev2v/migration-planner/pkg/log"
 	"github.com/kubev2v/migration-planner/pkg/metrics"
 	"github.com/kubev2v/migration-planner/pkg/migrations"
@@ -68,12 +68,11 @@ var runCmd = &cobra.Command{
 			}
 		}
 
-		// Initialize ISOs
-		zap.S().Info("Initializing RHCOS ISO")
-		if err := initializeIso(context.TODO(), cfg); err != nil {
-			zap.S().Fatalw("failed to initilized iso", "error", err)
+		// The migration planner API expects the RHCOS ISO to be on disk
+		if err := validateIso(cfg.Service.IsoPath); err != nil {
+			zap.S().Fatalw("validate iso", "error", err)
+			return err
 		}
-		zap.S().Info("RHCOS ISO initialized")
 
 		// Initialize OPA validator for policy validation
 		zap.S().Info("initializing OPA validator...")
@@ -151,42 +150,14 @@ func newListener(address string) (net.Listener, error) {
 	return net.Listen("tcp", address)
 }
 
-func initializeIso(ctx context.Context, cfg *config.Config) error {
-	// Check if ISO already exists:
-	isoPath := util.GetEnv("MIGRATION_PLANNER_ISO_PATH", "rhcos-live-iso.x86_64.iso")
-	if _, err := os.Stat(isoPath); err == nil {
-		return nil
-	}
-
-	out, err := os.Create(isoPath)
-	if err != nil {
+func validateIso(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("RHCOS ISO not found at path: %s", path)
+		} else if errors.Is(err, os.ErrPermission) {
+			return fmt.Errorf("permission denied for file: %s", path)
+		}
 		return err
 	}
-	defer out.Close()
-
-	md := iso.NewDownloaderManager()
-
-	minio, err := iso.NewMinioDownloader(
-		iso.WithEndpoint(cfg.Service.S3.Endpoint),
-		iso.WithBucket(cfg.Service.S3.Bucket),
-		iso.WithAccessKey(cfg.Service.S3.AccessKey),
-		iso.WithSecretKey(cfg.Service.S3.SecretKey),
-		iso.WithImage(cfg.Service.S3.IsoFileName, cfg.Service.RhcosImageSha256),
-	)
-	if err == nil {
-		md.Register(minio)
-	} else {
-		zap.S().Errorw("failed to create minio downloader", "error", err)
-	}
-
-	// register the default downloader of the official RHCOS image.
-	md.Register(iso.NewHttpDownloader(cfg.Service.RhcosImageName, cfg.Service.RhcosImageSha256))
-
-	if err := md.Download(ctx, out); err != nil {
-		// Remove the file from disk to allow the planner to retry the image download after restart.
-		_ = os.Remove(isoPath)
-		return err
-	}
-
 	return nil
 }

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -15,10 +15,8 @@ parameters:
     value: latest
   - name: MIGRATION_PLANNER_ISO_PATH
     value: /iso/rhcos-live-iso.x86_64.iso
-  - name: MIGRATION_PLANNER_ISO_URL
-    value: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/rhcos-4.19.0-x86_64-live-iso.x86_64.iso
-  - name: MIGRATION_PLANNER_ISO_SHA256
-    value: 6a9cf9df708e014a2b44f372ab870f873cf2db5685f9ef4518f52caa36160c36
+  - name: MIGRATION_PLANNER_ISO_IMAGE
+    value: quay.io/rh-ee-asegev/rhcos-live-iso.x86_64.iso:latest
   - name: MIGRATION_PLANNER_URL
     description: The API URL of the migration assessment
     required: true
@@ -404,6 +402,24 @@ objects:
           labels:
             app: migration-planner
         spec:
+          initContainers:
+            - name: pull-iso-from-quay
+              image: ghcr.io/oras-project/oras:v1.2.0
+              command: [ "sh", "-ceu" ]
+              args:
+                - |
+                  oras pull "${MIGRATION_PLANNER_ISO_IMAGE}" --output /iso
+                  chmod 0644 "${MIGRATION_PLANNER_ISO_PATH}"
+              volumeMounts:
+                - name: iso-storage
+                  mountPath: /iso
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+                limits:
+                  cpu: 200m
+                  memory: 512Mi
           containers:
             - name: envoy
               image: ${ENVOY_IMAGE}
@@ -493,10 +509,6 @@ objects:
                   value: ${INSECURE_REGISTRY}
                 - name: MIGRATION_PLANNER_ISO_PATH
                   value: ${MIGRATION_PLANNER_ISO_PATH}
-                - name: MIGRATION_PLANNER_ISO_URL
-                  value: ${MIGRATION_PLANNER_ISO_URL}
-                - name: MIGRATION_PLANNER_ISO_SHA256
-                  value: ${MIGRATION_PLANNER_ISO_SHA256}
                 # Svc Config values
                 - name: MIGRATION_PLANNER_ADDRESS
                   value: ${MIGRATION_PLANNER_ADDRESS}
@@ -527,22 +539,6 @@ objects:
                   value: ${MIGRATION_PLANNER_JWK_URL}
                 - name: MIGRATION_PLANNER_AGENT_AUTH_ENABLED
                   value: ${MIGRATION_PLANNER_AGENT_AUTH_ENABLED}
-                - name: MIGRATION_PLANNER_S3_ENDPOINT
-                  value: ${MIGRATION_PLANNER_S3_ENDPOINT}
-                - name: MIGRATION_PLANNER_S3_BUCKET
-                  value: ${MIGRATION_PLANNER_S3_BUCKET}
-                - name: MIGRATION_PLANNER_S3_ISO_FILENAME
-                  value: ${MIGRATION_PLANNER_S3_ISO_FILENAME}
-                - name: MIGRATION_PLANNER_S3_ACCESS_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${S3_SECRET_NAME}
-                      key: access_key
-                - name: MIGRATION_PLANNER_S3_SECRET_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: ${S3_SECRET_NAME}
-                      key: secret_key
                 # DB Config values
                 - name: MIGRATION_PLANNER_MIGRATIONS_FOLDER
                   value: ${MIGRATION_PLANNER_MIGRATIONS_FOLDER}

--- a/deploy/templates/service-template.yml
+++ b/deploy/templates/service-template.yml
@@ -403,12 +403,18 @@ objects:
             app: migration-planner
         spec:
           initContainers:
-            - name: pull-iso-from-quay
-              image: ghcr.io/oras-project/oras:v1.2.0
+            - name: pull-iso
+              image: quay.io/podman/stable:latest
               command: [ "sh", "-ceu" ]
               args:
                 - |
-                  oras pull "${MIGRATION_PLANNER_ISO_IMAGE}" --output /iso
+                  # Pull the OCI artifact (ISO image) from the registry into podman’s local storage
+                  podman artifact pull "${MIGRATION_PLANNER_ISO_IMAGE}"
+                  
+                  # Extract the ISO file from the pulled artifact to the desired path
+                  podman artifact extract "${MIGRATION_PLANNER_ISO_IMAGE}" "${MIGRATION_PLANNER_ISO_PATH}"
+                  
+                  # Set the correct permissions for the ISO file so it can be read by other processes
                   chmod 0644 "${MIGRATION_PLANNER_ISO_PATH}"
               volumeMounts:
                 - name: iso-storage

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,8 +32,7 @@ type svcConfig struct {
 	MigrationFolder      string `envconfig:"MIGRATION_PLANNER_MIGRATIONS_FOLDER" default:""`
 	OpaPoliciesFolder    string `envconfig:"MIGRATION_PLANNER_OPA_POLICIES_FOLDER" default:"/app/policies"`
 	S3                   S3
-	RhcosImageName       string `envconfig:"MIGRATION_PLANNER_ISO_URL" default:""`
-	RhcosImageSha256     string `envconfig:"MIGRATION_PLANNER_ISO_SHA256" default:""`
+	IsoPath              string `envconfig:"MIGRATION_PLANNER_ISO_PATH" default:"rhcos-live-iso.x86_64.iso"`
 }
 
 type Auth struct {


### PR DESCRIPTION
## Summary by Sourcery

Validate that the RHCOS ISO exists on disk at startup instead of downloading it in the API, and update the deployment and build process to obtain the ISO via an init container pulling from an OCI registry.

New Features:
- Add an init container in the Kubernetes service template to pull the RHCOS ISO from an OCI registry

Enhancements:
- Replace in-code ISO download and S3 config with a simple file existence validation in the API
- Simplify configuration by removing ISO URL and SHA environment variables and consolidating to a single ISO path

Build:
- Update Makefile to conditionally download the ISO only if it’s missing and require the image target before running

Deployment:
- Modify service-template.yml to use MIGRATION_PLANNER_ISO_IMAGE instead of direct ISO URL/SHA and add an initContainer for ISO retrieval
- Remove obsolete S3 download environment variables from the deployment manifest